### PR TITLE
Fixed Proof size computation

### DIFF
--- a/limbo.cpp
+++ b/limbo.cpp
@@ -1824,7 +1824,7 @@ unsigned int compute_proof_size(limbo_proof_t proof,
   result += proof.h_3.size() * 8;
 
   for (unsigned int i = 0; i < proof.proofs.size(); i++) {
-    result += proof.proofs[i].reveallist.first.size() * instance.seed_size;
+    result += proof.proofs[i].reveallist.first.size() * instance.seed_size * 8;
     result += proof.proofs[i].missing_seed_commitments.size() * 8;
     result += proof.proofs[i].witness_deltas.size();
     result += proof.proofs[i].mult_deltas.size();


### PR DESCRIPTION
In the computation of the proof size, the seed size is in bytes in instance.cpp, however, the returned signature size is in bits.
Therefore, a factor of 8 is missing in the calculation.

This PR fixes the computation by adding the missing factor of 8.